### PR TITLE
Fix #10 (add better ROL localizer capture without HSI)

### DIFF
--- a/Systems/kap140-autopilot.xml
+++ b/Systems/kap140-autopilot.xml
@@ -109,6 +109,50 @@
 	</filter>
 	
 	<filter>
+		<name>DG HeadingBug latch actual heading error</name>
+		<type>gain</type>
+		<gain>1.0</gain>
+		<input>
+			<condition>
+				<not><property>/autopilot/kap140/config/hsi-installed</property></not>
+				<or>
+					<property>/autopilot/internal/logic/rev-active</property>
+					<equals>
+						<property>autopilot/kap140/settings/lateral-arm</property>
+						<value>5</value>
+					</equals>
+				</or>
+			</condition>
+			<property>/autopilot/settings/heading-bug-latch</property>
+			<offset>
+				<expression>
+					<sum>
+						<value>180</value>
+						<property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+					</sum>
+				</expression>
+				<scale>-1.0</scale>
+			</offset>
+		</input>
+		<input>
+			<condition>
+				<not><property>/autopilot/kap140/config/hsi-installed</property></not>
+			</condition>
+			<property>/autopilot/settings/heading-bug-latch</property>
+			<offset>
+				<property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+				<scale>-1.0</scale>
+			</offset>
+		</input>
+		<input>0</input>
+		<output>/autopilot/internal/heading-bug-latch-error</output>
+		<period>
+			<min>-180</min>
+			<max>180</max>
+		</period>
+	</filter>
+
+	<filter>
 		<name>Target Intercept Angle P</name>
 		<type>gain</type>
 		<gain>12.5</gain>

--- a/kap140/kap140-proprules.xml
+++ b/kap140/kap140-proprules.xml
@@ -1869,6 +1869,37 @@ We have captured the localizer and the GS.
                     <value>6</value>
                 </less-than>
                 <property>instrumentation/nav-source/signal-valid</property>
+                
+                <or>
+                    <!-- with DG+ROL mode: capture once the calculated intercept course is smaller than the commanded ROL course difference -->
+                    <and>
+                        <not><property alias="/params/hsi-installed" /></not>
+                        <equals>
+                            <property>autopilot/kap140/settings/lateral-mode</property>
+                            <value>1</value>
+                        </equals>
+                        
+                        <greater-than-equals>
+                            <expression>
+                                <difference>
+                                    <abs><property>/autopilot/internal/heading-bug-latch-error</property></abs>
+                                    <abs><property>/autopilot/internal/intercept-angle</property></abs>
+                                </difference>
+                            </expression>
+                            <value>0</value>
+                        </greater-than-equals>
+                    </and>
+                    
+                    <!-- with HSI or DG+HDG: capture just using the radial course error -->
+                    <property alias="/params/hsi-installed" />
+                    <and>
+                        <not-equals>
+                            <property>autopilot/kap140/settings/lateral-mode</property>
+                            <value>1</value>
+                        </not-equals>
+                    </and>
+                </or>
+                
                 <less-than>
                     <expression>
                         <abs><property>instrumentation/nav-source/heading-needle-deflection-norm</property></abs>


### PR DESCRIPTION
Better capture of VOR/ILS beams without HSI from ROL mode

See also: https://github.com/HHS81/c182s/pull/403
Fixes #10 

----
btw; i noticed that here in your repo some params are not yet absolute - did you forgot to push your latest versions online?
https://github.com/reiszner/KAP140/blob/eb98eec8c1309d018a1dce846c9fde501de3edaf/Systems/kap140-autopilot.xml#L420
https://github.com/reiszner/KAP140/blob/eb98eec8c1309d018a1dce846c9fde501de3edaf/Systems/kap140-autopilot.xml#L455

and some more of this kind: `<property>`**`/autopilot/kap140/config/`**`gain-roll</property>`
https://github.com/reiszner/KAP140/blob/eb98eec8c1309d018a1dce846c9fde501de3edaf/Systems/kap140-autopilot.xml#L385